### PR TITLE
Remove temp dir before the execution of actual dynamic action

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Given a step like so:
 If you want your `uses` to be dynamic you can do:
 
 ```yaml
-- uses: jenseng/dynamic-uses@v1
+- uses: jenseng/dynamic-uses@v1.1
   with:
     # now you can use expressions 🥳
     uses: actions/setup-node@${{ inputs.version }}
@@ -51,7 +51,7 @@ Because the `uses` is hardcoded, it will always use `cleanup@v1`. This makes it 
 Taking our example above, we can make it work however we need to with `dynamic-uses`:
 
 ```yaml
-- uses: jenseng/dynamic-uses@v1
+- uses: jenseng/dynamic-uses@v1.1
   with:
     # ensure we use the right version:
     #  - within this repo, we want the `sha`

--- a/action.yml
+++ b/action.yml
@@ -27,6 +27,8 @@ runs:
         runs:
           using: composite
           steps:
+          - run: rm -rf ./.tmp-dynamic-uses
+            shell: sh
           - name: Run
             id: run
             uses: ${{ inputs.uses }}
@@ -36,6 +38,6 @@ runs:
       id: run
       uses: ./.tmp-dynamic-uses
     - name: Cleanup
-      if: always()
+      if: always() && steps.run.outcome != 'success'
       shell: bash
       run: rm -rf ./.tmp-dynamic-uses


### PR DESCRIPTION
In case of dynamic action that does something with all the files and directories in the working directory, like copying them somewhere else, `.tmp-dynamic-uses` will be also included. 

With this change no workarounds are needed and workflows stay simple.