### PR TITLE
Fix `with:`, decode from JSON string

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -32,7 +32,7 @@ runs:
           - name: Run
             id: run
             uses: ${{ inputs.uses }}
-            with: ${{ inputs.with || '{}' }}
+            with: ${{ fromJSON(inputs.with) || fromJSON('{}') }}
         DYNAMIC_USES_EOF
     - name: Run
       id: run


### PR DESCRIPTION
`with:` parameters should be decoded from JSON when generating temporary action YAML file. I discovered this bug when passing multiple keys/values in the JSON string.

This is the action I want to dynamically use (`example-org/test-repo/.github/actions/test.yaml`):

```yaml
name: Test action

inputs:
  version:
    required: true
  repository:
    required: true
  token:
    required: false

runs:
  using: "composite"
  steps:
    - name: Do something simple
      shell: bash
      run: |
        echo -n "Version: ${{ inputs.version }}"
        echo -n "Repository: ${{ inputs.repository }}"
        if [ -z "${{ inputs.token }}" ]; then
          echo -n "Token: is not set"
        else
          echo -n "Token: is set"
        fi
```

This is how I'm setting up my workflow (`example-org/test-repo/.github/workflows/test.yaml`):

```yaml
name: Test workflow

on:
  pull_request:
    branches: [main]
  push:
    branches: [main]

  workflow_call:
    inputs:
      version:
        required: true
        type: string
      repository:
        required: false
        type: string
        default: "${{ github.repository_owner }}/test-repo"
    secrets:
      token:
        required: false

jobs:

  test-action:
    runs-on: ubuntu-latest
    steps:
      - name: Test using dynamic action
        uses: jenseng/dynamic-uses@v1
        with:
          uses: "${{ inputs.repository }}/.github/actions/test@${{ inputs.version }}"
          with: |
            '{
              "version": "${{ inputs.version }}",
              "repository": "${{ inputs.repository }}",
              "token": "${{ secrets.token }}",
            }'
```

And here is the output from a failed run:

```console
▼ Run jenseng/dynamic-uses@v1
  with:
    uses: example-org/test-repo/.github/actions/test@v0.1.0
    with: '{
    "version": "v0.1.0",
    "repository": "example-org/test-repo",
    "token": "***",
  }'
  
▼ Run mkdir -p ./.tmp-dynamic-uses &&
  mkdir -p ./.tmp-dynamic-uses &&
  cat <<'DYNAMIC_USES_EOF' >./.tmp-dynamic-uses/action.yml
  outputs:
    outputs:
      value: ${{ toJSON(steps.run.outputs) }}
  runs:
    using: composite
    steps:
    - run: rm -rf ./.tmp-dynamic-uses
      shell: sh
    - name: Run
      id: run
      uses: example-org/test-repo/.github/actions/test@v0.1.0
      with: '{
    "version": "v0.1.0",
    "repository": "example-org/test-repo",
    "token": "***",
  }'
  
  DYNAMIC_USES_EOF
  shell: /usr/bin/bash --noprofile --norc -e -o pipefail {0}
Error: /home/runner/work/dummy/dummy/./.tmp-dynamic-uses/action.yml (Line: 12, Col: 11): Unexpected value '{ "version": "v0.1.0", "repository": "example-org/test-repo", "token": "***", }'
Error: /home/runner/work/dummy/dummy/./.tmp-dynamic-uses/action.yml: Input string was not in a correct format.
Error: System.ArgumentException: Unexpected type '' encountered while reading 'action manifest root'. The type 'MappingToken' was expected.
   at GitHub.DistributedTask.ObjectTemplating.Tokens.TemplateTokenExtensions.AssertMapping(TemplateToken value, String objectDescription)
   at GitHub.Runner.Worker.ActionManifestManager.Load(IExecutionContext executionContext, String manifestFile)
Error: Failed to load /home/runner/work/dummy/dummy/./.tmp-dynamic-uses/action.yml
▼ Run rm -rf ./.tmp-dynamic-uses
  rm -rf ./.tmp-dynamic-uses
  shell: /usr/bin/bash --noprofile --norc -e -o pipefail {0}
```

The provided patch fixes the above issue.