### PR TITLE
Add matrix action for repeated usage based on inputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,40 @@ with: |
    ```
 - GitHub Actions has several bugs impacting nested composite actions (e.g. https://github.com/actions/runner/issues/2800, https://github.com/actions/runner/issues/2009). When you use dynamic-uses to call another composite action, these bugs can cause problems like blank/wrong `inputs` or `ouputs` within that action. As a workaround, you can try passing data along with `GITHUB_ENV` instead.
 
+## dynamic-uses/matrix
+
+This is a variant of `dynamic-uses` that allows you to call another action multiple times with different parameters, using a matrix pattern. Each item in the matrix is passed as separate input parameters to the action, rather than being treated as a single `matrix` input.
+
+This version doesn't support capturing outputs yet. It also runs everything in sequence, not in parallel. For parallelism, you need to use different jobs, which already support matrix on their own.
+
+### When would I use this?
+
+When you want to run the same action multiple times with different configurations. For example:
+- Building multiple sub-applications with different settings
+- Processing multiple items with the same action
+
+### Usage
+
+Deploy multiple microservices to different environments:
+
+```yaml
+- uses: jenseng/dynamic-uses/matrix@matrix-action
+  with:
+    uses: my-org/deploy-service@v1
+    matrix: |
+      [
+        {"service": "api", "env": "staging"},
+        {"service": "web", "env": "staging"},
+        {"service": "api", "env": "production"},
+        {"service": "web", "env": "production"}
+      ]
+    with: |
+      region: us-east-1
+      registry: ${{ secrets.REGISTRY }}
+```
+
+This will deploy 4 services in sequence, each with the appropriate `service` and `env`, while sharing the same `region` and `registry` credentials.
+
 ## License
 
 The scripts and documentation in this project are released under the [ISC License](./LICENSE.md)

--- a/matrix/action.yml
+++ b/matrix/action.yml
@@ -1,0 +1,62 @@
+name: Dynamic Uses
+description: Dynamically resolve and use another GitHub action. Workaround for https://github.com/actions/runner/issues/895
+author: Jon Jensen
+inputs:
+  uses:
+    description: Action reference or path, e.g. `actions/setup-node@v3`
+    required: true
+  matrix:
+    description: 'Array of objects for matrix, e.g. `[{"node": "18"}, {"node": "20"}]` - values accessible as MATRIX_FIELD in env'
+    required: false
+    default: "[]"
+  with:
+    description: 'YAML/JSON string of `inputs` for the action (shared across all matrix items), e.g. `node-version: 18` or `{"node-version": "18"}`'
+    required: false
+    default: "{}"
+runs:
+  using: composite
+  steps:
+    - name: Setup
+      shell: bash
+      env:
+        uses: ${{ inputs.uses }}
+        matrix: ${{ inputs.matrix }}
+        with: ${{ inputs.with }}
+      run: |
+        mkdir -p ./.tmp-dynamic-uses
+        
+        # Initialize the action.yml file with the header
+        cat > ./.tmp-dynamic-uses/action.yml <<DYNAMIC_USES_EOF
+        runs:
+          using: composite
+          steps:
+          - run: rm -rf ./.tmp-dynamic-uses
+            shell: bash
+        DYNAMIC_USES_EOF
+        
+        # Count matrix items
+        count=$(echo "$matrix" | jq 'if type == "array" then length else 0 end')
+        
+        # Generate a Run-N step for each item in the matrix array
+        echo "$matrix" | jq -r 'if type == "array" then . else [] end | to_entries | .[] | @base64' | while IFS= read -r entry_b64; do
+          entry=$(echo "$entry_b64" | base64 -d)
+          index=$(echo "$entry" | jq -r '.key')
+          matrix_item=$(echo "$entry" | jq -c '.value')
+          
+          # Append the step to the file
+          cat >> ./.tmp-dynamic-uses/action.yml <<DYNAMIC_USES_EOF
+          - name: Run-$index
+            id: run-$index
+            uses: '$(echo "$uses" | sed "s/'/''/g")'
+            with:
+        $(echo "$matrix_item" | jq -r 'to_entries[] | "              \(.key): " + (.value | @json)')
+        $(echo "$with" | sed -e 's/^/              /' -e '/^[[:space:]]*$/d')
+        DYNAMIC_USES_EOF
+        done
+    - name: Run
+      id: run
+      uses: ./.tmp-dynamic-uses
+    - name: Cleanup
+      if: always() && steps.run.outcome != 'success'
+      shell: bash
+      run: rm -rf ./.tmp-dynamic-uses


### PR DESCRIPTION
This pull request introduces a new variant of the `dynamic-uses` GitHub Action called `dynamic-uses/matrix`, which enables running another action multiple times with different parameters using a matrix pattern. The documentation has been updated to explain this new feature, and a new composite action has been added to implement the matrix functionality.

**New matrix variant for dynamic-uses:**

* Added a new composite action `matrix/action.yml` that allows users to specify a matrix of input objects, running the referenced action once for each matrix item with its own parameters. Each run is executed sequentially, not in parallel, and outputs are not yet supported.

**Documentation updates:**

* Updated `README.md` to document the new `dynamic-uses/matrix` action, including when to use it, usage examples, and its current limitations.